### PR TITLE
chore: Update dependencies to latest stable versions

### DIFF
--- a/android_app/buildozer.spec
+++ b/android_app/buildozer.spec
@@ -68,7 +68,7 @@ orientation = portrait, landscape, portrait-reverse, landscape-reverse
 osx.python_version = 3
 
 # Kivy version to use
-osx.kivy_version = 2.2.1
+osx.kivy_version = 2.3.1
 
 #
 # Android specific

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,5 @@
-httpx>=0.25.0
-rich>=13.0.0
+# HTTP client for API requests
+httpx>=0.28.0
+
+# Terminal UI formatting
+rich>=14.0.0


### PR DESCRIPTION
- Update httpx from >=0.25.0 to >=0.28.0 (latest: 0.28.1)
- Update rich from >=13.0.0 to >=14.0.0 (latest: 14.2.0)
- Update Kivy from 2.2.1 to 2.3.1 in buildozer.spec
- Add comments to requirements.txt for clarity

All packages audited for security vulnerabilities (none found).