### PR TITLE
Rename border attribute to border_line for clarity

### DIFF
--- a/android_app/main.py
+++ b/android_app/main.py
@@ -237,11 +237,11 @@ class OutlineButton(Button):
 
         with self.canvas.after:
             Color(*get_color_from_hex(self.border_color))
-            self.border = Line(rounded_rectangle=(self.x, self.y, self.width, self.height, dp(4)), width=1.5)
+            self.border_line = Line(rounded_rectangle=(self.x, self.y, self.width, self.height, dp(4)), width=1.5)
         self.bind(pos=self._update, size=self._update)
 
     def _update(self, *args):
-        self.border.rounded_rectangle = (self.x, self.y, self.width, self.height, dp(4))
+        self.border_line.rounded_rectangle = (self.x, self.y, self.width, self.height, dp(4))
 
 
 class PlaceholderCard(BoxLayout):


### PR DESCRIPTION
## Summary
Renamed the `border` attribute to `border_line` in the border initialization and update logic to improve code clarity and avoid potential naming conflicts.

## Changes
- Renamed `self.border` to `self.border_line` in the `__init__` method where the Line object is created
- Updated the corresponding reference in the `_update` method to use the new `self.border_line` attribute name

## Details
This change improves code readability by using a more descriptive attribute name that clearly indicates the object is a Line instance, reducing ambiguity and potential confusion with other border-related attributes or methods.

https://claude.ai/code/session_01XdRxXHRrq5CaE4omLUMWKT