### PR TITLE
feat: Add Samsung Galaxy Z Fold 6 responsive layouts

### DIFF
--- a/android_app/screens/base_screen.py
+++ b/android_app/screens/base_screen.py
@@ -1,0 +1,240 @@
+"""
+Base Screen with Responsive Support
+
+Provides a base class for screens that automatically adapts
+to Samsung Galaxy Z Fold 6 screen modes.
+"""
+
+import os
+import sys
+
+from kivy.uix.screenmanager import Screen
+from kivy.uix.boxlayout import BoxLayout
+from kivy.uix.scrollview import ScrollView
+from kivy.uix.gridlayout import GridLayout
+from kivy.uix.label import Label
+from kivy.uix.button import Button
+from kivy.metrics import dp, sp
+from kivy.utils import get_color_from_hex
+from kivy.graphics import Color, Rectangle, RoundedRectangle
+from kivy.properties import StringProperty, BooleanProperty, NumericProperty
+from kivy.clock import Clock
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from utils.responsive import (
+    get_responsive_manager,
+    ScreenMode,
+    is_cover_mode,
+    is_main_mode,
+)
+
+
+# Color scheme
+COLORS = {
+    'background': '#f5f5f5',
+    'surface': '#ffffff',
+    'primary': '#4caf50',
+    'primary_dark': '#388e3c',
+    'secondary': '#2196f3',
+    'accent': '#ff9800',
+    'text': '#212121',
+    'text_secondary': '#757575',
+    'text_muted': '#9e9e9e',
+    'border': '#e0e0e0',
+}
+
+
+class ResponsiveScreen(Screen):
+    """
+    Base screen class with responsive layout support.
+
+    Automatically adapts to Samsung Fold 6 screen modes:
+    - Cover Screen: Compact single-column layout
+    - Main Screen: Expanded multi-column layout
+
+    Subclasses should override:
+    - _build_content(): Build the main content
+    - _on_mode_change(): Handle screen mode changes
+    """
+
+    lang = StringProperty("en")
+    current_mode = StringProperty(ScreenMode.PHONE)
+    is_cover = BooleanProperty(False)
+    is_main = BooleanProperty(False)
+
+    # Layout properties that update based on mode
+    grid_cols = NumericProperty(1)
+    content_padding = NumericProperty(12)
+    content_spacing = NumericProperty(10)
+    card_height = NumericProperty(120)
+    font_scale = NumericProperty(1.0)
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.responsive = get_responsive_manager()
+        self._content_built = False
+        self._bind_responsive()
+
+    def _bind_responsive(self):
+        """Bind to responsive manager changes."""
+        self.responsive.bind(screen_mode=self._handle_mode_change)
+        self._sync_properties()
+
+    def _sync_properties(self):
+        """Sync properties from responsive manager."""
+        self.current_mode = self.responsive.screen_mode
+        self.is_cover = self.responsive.is_cover_mode
+        self.is_main = self.responsive.is_main_mode
+        self.grid_cols = self.responsive.grid_columns
+        self.content_padding = self.responsive.padding
+        self.content_spacing = self.responsive.spacing
+        self.card_height = self.responsive.card_height
+        self.font_scale = self.responsive.font_scale
+
+    def _handle_mode_change(self, instance, mode):
+        """Handle screen mode change."""
+        self._sync_properties()
+        if self._content_built:
+            self._on_mode_change(mode)
+
+    def on_enter(self):
+        """Called when screen is displayed."""
+        if not self._content_built:
+            self._build_ui()
+            self._content_built = True
+        self._sync_properties()
+
+    def _build_ui(self):
+        """Build the screen UI - override in subclass."""
+        pass
+
+    def _on_mode_change(self, mode):
+        """Handle mode change - override in subclass to adapt layout."""
+        pass
+
+    # =========================================================================
+    # HELPER METHODS FOR RESPONSIVE LAYOUTS
+    # =========================================================================
+
+    def get_scaled_font(self, base_sp: float) -> float:
+        """Get font size scaled for current mode."""
+        return sp(base_sp * self.font_scale)
+
+    def create_responsive_grid(self, **kwargs) -> GridLayout:
+        """Create a GridLayout that adapts columns to screen mode."""
+        cols = kwargs.pop('cols', None) or self.grid_cols
+        spacing = kwargs.pop('spacing', None) or self.content_spacing
+
+        grid = GridLayout(
+            cols=cols,
+            spacing=spacing,
+            size_hint_y=None,
+            **kwargs
+        )
+        grid.bind(minimum_height=grid.setter('height'))
+        return grid
+
+    def create_card(self, **kwargs) -> BoxLayout:
+        """Create a card container with responsive styling."""
+        height = kwargs.pop('height', None) or self.card_height
+        padding = kwargs.pop('padding', None) or dp(12)
+
+        card = BoxLayout(
+            orientation='vertical',
+            size_hint_y=None,
+            height=height,
+            padding=padding,
+            **kwargs
+        )
+
+        with card.canvas.before:
+            Color(*get_color_from_hex(COLORS['surface']))
+            card._bg = RoundedRectangle(
+                pos=card.pos,
+                size=card.size,
+                radius=[dp(8)]
+            )
+        card.bind(
+            pos=lambda *a, c=card: setattr(c._bg, 'pos', c.pos),
+            size=lambda *a, c=card: setattr(c._bg, 'size', c.size)
+        )
+
+        return card
+
+    def create_header(self, title: str, show_back: bool = True) -> BoxLayout:
+        """Create a responsive header with optional back button."""
+        header = BoxLayout(
+            size_hint_y=None,
+            height=dp(45) if not self.is_cover else dp(40),
+            spacing=dp(10)
+        )
+
+        if show_back:
+            back_btn = Button(
+                text='<',
+                size_hint_x=None,
+                width=dp(40) if not self.is_cover else dp(35),
+                background_color=get_color_from_hex(COLORS['text_muted']),
+                font_size=self.get_scaled_font(20)
+            )
+            back_btn.bind(on_release=self._go_back)
+            header.add_widget(back_btn)
+
+        title_label = Label(
+            text=title,
+            font_size=self.get_scaled_font(18),
+            bold=True,
+            color=get_color_from_hex(COLORS['text']),
+            halign='left',
+            valign='middle'
+        )
+        title_label.bind(size=title_label.setter('text_size'))
+        header.add_widget(title_label)
+
+        return header
+
+    def create_section_label(self, text: str) -> Label:
+        """Create a section header label."""
+        label = Label(
+            text=text,
+            font_size=self.get_scaled_font(14),
+            bold=True,
+            color=get_color_from_hex(COLORS['text']),
+            size_hint_y=None,
+            height=dp(30),
+            halign='left',
+            valign='bottom'
+        )
+        label.bind(size=label.setter('text_size'))
+        return label
+
+    def _go_back(self, *args):
+        """Navigate back - override if needed."""
+        if self.manager:
+            self.manager.transition.direction = 'right'
+            self.manager.current = 'home'
+
+    # =========================================================================
+    # LAYOUT HELPERS FOR DIFFERENT MODES
+    # =========================================================================
+
+    def should_use_side_panel(self) -> bool:
+        """Check if side-by-side layout should be used."""
+        return self.is_main and not self.is_cover
+
+    def get_optimal_button_width(self) -> float:
+        """Get optimal button width for current mode."""
+        if self.is_cover:
+            return dp(70)
+        elif self.is_main:
+            return dp(100)
+        return dp(85)
+
+    def get_optimal_card_columns(self) -> int:
+        """Get optimal number of card columns."""
+        if self.is_cover:
+            return 1
+        elif self.is_main:
+            return 2
+        return 1

--- a/android_app/utils/__init__.py
+++ b/android_app/utils/__init__.py
@@ -1,0 +1,28 @@
+"""Utilities module for TCG App."""
+from .responsive import (
+    ResponsiveManager,
+    ScreenMode,
+    get_responsive_manager,
+    is_cover_mode,
+    is_main_mode,
+    is_foldable,
+    get_grid_columns,
+    get_card_height,
+    scaled_font,
+    get_padding,
+    get_spacing,
+)
+
+__all__ = [
+    'ResponsiveManager',
+    'ScreenMode',
+    'get_responsive_manager',
+    'is_cover_mode',
+    'is_main_mode',
+    'is_foldable',
+    'get_grid_columns',
+    'get_card_height',
+    'scaled_font',
+    'get_padding',
+    'get_spacing',
+]

--- a/android_app/utils/responsive.py
+++ b/android_app/utils/responsive.py
@@ -1,0 +1,267 @@
+"""
+Responsive Layout Utilities for Samsung Galaxy Z Fold 6
+
+This module provides utilities for detecting screen mode and adapting
+layouts for foldable devices.
+
+Samsung Galaxy Z Fold 6 Specifications:
+- Cover Screen: ~6.2" diagonal, 904x2316 pixels (~25:9 aspect ratio)
+- Main Screen: ~7.6" diagonal, 1812x2176 pixels (~4:3 aspect ratio)
+"""
+
+from kivy.core.window import Window
+from kivy.event import EventDispatcher
+from kivy.properties import (
+    StringProperty,
+    NumericProperty,
+    BooleanProperty,
+    ListProperty
+)
+from kivy.metrics import dp, sp
+from kivy.clock import Clock
+
+
+class ScreenMode:
+    """Screen mode constants."""
+    COVER = 'cover'       # Narrow cover screen (folded)
+    MAIN = 'main'         # Large main screen (unfolded)
+    PHONE = 'phone'       # Regular phone screen
+    TABLET = 'tablet'     # Tablet screen
+
+
+class ResponsiveManager(EventDispatcher):
+    """
+    Manager for responsive layouts on foldable devices.
+
+    Detects screen mode and provides layout parameters based on
+    current screen dimensions.
+
+    Usage:
+        responsive = ResponsiveManager()
+
+        # Get current mode
+        if responsive.is_cover_mode:
+            # Use compact layout
+        else:
+            # Use expanded layout
+
+        # Bind to mode changes
+        responsive.bind(screen_mode=my_callback)
+    """
+
+    # Properties
+    screen_mode = StringProperty(ScreenMode.PHONE)
+    screen_width = NumericProperty(0)
+    screen_height = NumericProperty(0)
+    aspect_ratio = NumericProperty(1.0)
+
+    # Boolean helpers
+    is_cover_mode = BooleanProperty(False)
+    is_main_mode = BooleanProperty(False)
+    is_foldable = BooleanProperty(False)
+    is_landscape = BooleanProperty(False)
+
+    # Layout parameters (updated based on mode)
+    grid_columns = NumericProperty(1)
+    card_height = NumericProperty(120)
+    font_scale = NumericProperty(1.0)
+    padding = NumericProperty(12)
+    spacing = NumericProperty(10)
+
+    # Breakpoints (in dp)
+    COVER_MAX_WIDTH = 400      # Cover screen max width
+    MAIN_MIN_WIDTH = 600       # Main screen min width
+    TABLET_MIN_WIDTH = 800     # Tablet min width
+
+    # Aspect ratio thresholds
+    NARROW_RATIO = 2.5         # Cover screen is very narrow (~25:9 = 2.78)
+    WIDE_RATIO = 1.5           # Below this is considered tablet-like
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self._update_scheduled = None
+
+        # Initial detection
+        self._detect_mode()
+
+        # Bind to window size changes
+        Window.bind(size=self._on_window_resize)
+
+    def _on_window_resize(self, instance, size):
+        """Handle window resize - schedule mode detection."""
+        if self._update_scheduled:
+            self._update_scheduled.cancel()
+        self._update_scheduled = Clock.schedule_once(
+            lambda dt: self._detect_mode(), 0.1
+        )
+
+    def _detect_mode(self):
+        """Detect current screen mode based on dimensions."""
+        width = Window.width
+        height = Window.height
+
+        self.screen_width = width
+        self.screen_height = height
+
+        # Calculate aspect ratio (height/width for portrait orientation)
+        if width > 0:
+            self.aspect_ratio = height / width if height > width else width / height
+
+        self.is_landscape = width > height
+
+        # Detect foldable and specific mode
+        width_dp = width / Window.density if Window.density else width
+
+        # Determine screen mode
+        if self.aspect_ratio >= self.NARROW_RATIO:
+            # Very narrow screen - Cover mode
+            self.screen_mode = ScreenMode.COVER
+            self.is_cover_mode = True
+            self.is_main_mode = False
+            self.is_foldable = True
+        elif width_dp >= self.MAIN_MIN_WIDTH and self.aspect_ratio < self.WIDE_RATIO:
+            # Wide screen with tablet-like ratio - Main mode
+            self.screen_mode = ScreenMode.MAIN
+            self.is_cover_mode = False
+            self.is_main_mode = True
+            self.is_foldable = True
+        elif width_dp >= self.TABLET_MIN_WIDTH:
+            # Very wide - Tablet mode
+            self.screen_mode = ScreenMode.TABLET
+            self.is_cover_mode = False
+            self.is_main_mode = False
+            self.is_foldable = False
+        else:
+            # Regular phone
+            self.screen_mode = ScreenMode.PHONE
+            self.is_cover_mode = False
+            self.is_main_mode = False
+            self.is_foldable = False
+
+        # Update layout parameters
+        self._update_layout_params()
+
+    def _update_layout_params(self):
+        """Update layout parameters based on current mode."""
+        if self.screen_mode == ScreenMode.COVER:
+            # Compact layout for cover screen
+            self.grid_columns = 1
+            self.card_height = dp(100)
+            self.font_scale = 0.9
+            self.padding = dp(8)
+            self.spacing = dp(6)
+
+        elif self.screen_mode == ScreenMode.MAIN:
+            # Expanded layout for main screen
+            self.grid_columns = 2
+            self.card_height = dp(140)
+            self.font_scale = 1.1
+            self.padding = dp(16)
+            self.spacing = dp(12)
+
+        elif self.screen_mode == ScreenMode.TABLET:
+            # Large layout for tablets
+            self.grid_columns = 3
+            self.card_height = dp(160)
+            self.font_scale = 1.2
+            self.padding = dp(20)
+            self.spacing = dp(16)
+
+        else:
+            # Standard phone layout
+            self.grid_columns = 1
+            self.card_height = dp(120)
+            self.font_scale = 1.0
+            self.padding = dp(12)
+            self.spacing = dp(10)
+
+    def get_scaled_font(self, base_sp: float) -> float:
+        """Get scaled font size based on current mode."""
+        return sp(base_sp * self.font_scale)
+
+    def get_layout_params(self) -> dict:
+        """Get all layout parameters as a dictionary."""
+        return {
+            'mode': self.screen_mode,
+            'is_cover': self.is_cover_mode,
+            'is_main': self.is_main_mode,
+            'is_foldable': self.is_foldable,
+            'is_landscape': self.is_landscape,
+            'grid_columns': self.grid_columns,
+            'card_height': self.card_height,
+            'font_scale': self.font_scale,
+            'padding': self.padding,
+            'spacing': self.spacing,
+            'screen_width': self.screen_width,
+            'screen_height': self.screen_height,
+        }
+
+    def should_use_side_panel(self) -> bool:
+        """Check if side panel layout should be used."""
+        return self.screen_mode in (ScreenMode.MAIN, ScreenMode.TABLET)
+
+    def get_optimal_columns(self, item_min_width: float = 150) -> int:
+        """Calculate optimal number of columns based on item width."""
+        available_width = self.screen_width - (self.padding * 2)
+        columns = max(1, int(available_width / dp(item_min_width)))
+
+        # Limit based on mode
+        if self.screen_mode == ScreenMode.COVER:
+            return min(columns, 2)
+        elif self.screen_mode == ScreenMode.MAIN:
+            return min(columns, 3)
+        else:
+            return min(columns, 4)
+
+
+# Singleton instance
+_responsive_manager = None
+
+
+def get_responsive_manager() -> ResponsiveManager:
+    """Get the singleton ResponsiveManager instance."""
+    global _responsive_manager
+    if _responsive_manager is None:
+        _responsive_manager = ResponsiveManager()
+    return _responsive_manager
+
+
+# Convenience functions
+def is_cover_mode() -> bool:
+    """Check if currently in cover screen mode."""
+    return get_responsive_manager().is_cover_mode
+
+
+def is_main_mode() -> bool:
+    """Check if currently in main screen mode."""
+    return get_responsive_manager().is_main_mode
+
+
+def is_foldable() -> bool:
+    """Check if device is detected as foldable."""
+    return get_responsive_manager().is_foldable
+
+
+def get_grid_columns() -> int:
+    """Get recommended number of grid columns."""
+    return get_responsive_manager().grid_columns
+
+
+def get_card_height() -> float:
+    """Get recommended card height."""
+    return get_responsive_manager().card_height
+
+
+def scaled_font(base_sp: float) -> float:
+    """Get scaled font size."""
+    return get_responsive_manager().get_scaled_font(base_sp)
+
+
+def get_padding() -> float:
+    """Get recommended padding."""
+    return get_responsive_manager().padding
+
+
+def get_spacing() -> float:
+    """Get recommended spacing."""
+    return get_responsive_manager().spacing


### PR DESCRIPTION
Responsive Utilities (android_app/utils/responsive.py):
- ResponsiveManager class for detecting screen mode
- Cover Screen detection (~25:9 aspect ratio, narrow)
- Main Screen detection (~4:3 aspect ratio, tablet-like)
- Auto-updating layout parameters on screen resize
- Breakpoints for Cover/Main/Phone/Tablet modes

Base Screen (android_app/screens/base_screen.py):
- ResponsiveScreen base class with responsive support
- Helper methods for creating responsive grids and cards
- Scaled font sizes based on screen mode

HomeScreen Updates:
- Adaptive layout for Cover vs Main screen
- GridLayout quick actions on Main screen (2x3)
- BoxLayout quick actions on Cover screen (single row)
- Additional buttons (News, Calendar) on expanded view
- Dynamic padding and spacing

Samsung Fold 6 Specs Supported:
- Cover Screen: ~6.2" diagonal, 904x2316 pixels
- Main Screen: ~7.6" diagonal, 1812x2176 pixels

https://claude.ai/code/session_01JL3vxL4Arc2jsiRqucwsyf