### PR TITLE
Switch p4a branch to develop for pyjnius/Cython compatibility

### DIFF
--- a/android_app/buildozer.spec
+++ b/android_app/buildozer.spec
@@ -310,7 +310,8 @@ android.allow_backup = True
 #p4a.fork = kivy
 
 # (str) python-for-android branch to use, defaults to master
-#p4a.branch = master
+# Using develop branch for pyjnius/Cython compatibility fixes
+p4a.branch = develop
 
 # (str) python-for-android specific commit to use, defaults to HEAD, must be within p4a.branch
 #p4a.commit = HEAD


### PR DESCRIPTION
## Summary
Updated the python-for-android (p4a) branch configuration from the default master branch to the develop branch to resolve compatibility issues with pyjnius and Cython.

## Changes
- Changed `p4a.branch` from commented-out `master` (default) to active `develop` branch
- Added explanatory comment documenting the reason for this change

## Details
The develop branch of python-for-android contains fixes and improvements for pyjnius and Cython compatibility that are not yet available in the master branch. This change ensures the Android build uses a more compatible version of p4a for the project's dependencies.

https://claude.ai/code/session_015W6A2ZWBpKD4sY3u5ZVDZ7