### PR TITLE
fix: Add sqlite3 to buildozer requirements

### DIFF
--- a/android_app/buildozer.spec
+++ b/android_app/buildozer.spec
@@ -37,7 +37,7 @@ version = 2.0.0
 
 # (list) Application requirements
 # comma separated e.g. requirements = sqlite3,kivy
-requirements = python3,kivy
+requirements = python3,kivy,sqlite3
 
 # (str) Custom source folders for requirements
 # Sets custom source for any requirements with recipes


### PR DESCRIPTION
The user_database.py service uses sqlite3 which needs to be explicitly included in the Android build requirements.

https://claude.ai/code/session_015W6A2ZWBpKD4sY3u5ZVDZ7