### PR TITLE
fix: Correções de compatibilidade Python 3.10

### DIFF
--- a/backend/app/core/i18n.py
+++ b/backend/app/core/i18n.py
@@ -88,3 +88,9 @@ def get_localized(en: str, pt: str, lang: Language = Language.EN) -> str:
     if lang == Language.PT:
         return pt
     return en
+
+
+# Alias for convenience
+translate = get_translation
+
+__all__ = ["Language", "TRANSLATIONS", "get_translation", "get_localized", "translate"]

--- a/backend/app/models/tournament.py
+++ b/backend/app/models/tournament.py
@@ -1,5 +1,7 @@
 """Tournament and statistics ORM models: tournaments, news_articles, card_usage_stats, deck_usage_stats."""
 
+from __future__ import annotations
+
 from datetime import date, datetime
 from typing import Optional
 

--- a/backend/app/schemas/card.py
+++ b/backend/app/schemas/card.py
@@ -102,3 +102,17 @@ class CardSearchQuery(BaseModel):
     is_ex: Optional[bool] = None
     limit: int = 20
     offset: int = 0
+
+
+# Alias for backwards compatibility
+CardSearchParams = CardSearchQuery
+
+__all__ = [
+    "CardSetOut",
+    "CardAbilityOut",
+    "CardAttackOut",
+    "CardFunctionOut",
+    "CardOut",
+    "CardSearchQuery",
+    "CardSearchParams",
+]

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -4,7 +4,7 @@ version = "3.0.0"
 description = "Pokemon TCG Deck Analysis Platform - Backend API"
 authors = [{name = "Bruno Strumendo", email = "strumendo@gmail.com"}]
 requires-python = ">=3.10"
-license = {text = "MIT"}
+license = "MIT"
 
 dependencies = [
     "fastapi>=0.115.0",
@@ -31,6 +31,9 @@ dev = [
     "ruff>=0.8.0",
     "mypy>=1.13.0",
 ]
+
+[tool.setuptools.packages.find]
+include = ["app*"]
 
 [build-system]
 requires = ["setuptools>=75.0"]


### PR DESCRIPTION
## Summary
- Corrige formato deprecated da licença no `pyproject.toml` e adiciona configuração `setuptools.packages.find`
- Resolve `TypeError` com `Optional` e `MappedColumn` no Python 3.10 em `tournament.py`
- Adiciona aliases de compatibilidade: `translate` em `i18n.py` e `CardSearchParams` em `card.py`

## Contexto
Bugs encontrados durante testes completos da plataforma v3.0 com o deck Dragapult.

## Arquivos alterados
| Arquivo | Correção |
|---------|----------|
| `backend/pyproject.toml` | Formato `license` e `[tool.setuptools.packages.find]` |
| `backend/app/models/tournament.py` | `from __future__ import annotations` |
| `backend/app/core/i18n.py` | Alias `translate = get_translation` |
| `backend/app/schemas/card.py` | Alias `CardSearchParams = CardSearchQuery` |

## Test plan
- [x] 12/12 testes de importação e funcionalidade passaram
- [ ] Testes de integração com Docker (PostgreSQL + Redis)

🤖 Generated with [Claude Code](https://claude.com/claude-code)